### PR TITLE
upgrade asciidoctor-gradle-plugin to 1.5.3

### DIFF
--- a/cmdline/build.gradle
+++ b/cmdline/build.gradle
@@ -15,7 +15,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.1'
+        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
     }
 }
 

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 
     dependencies {
-        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.2'
+        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
     }
 }
 


### PR DESCRIPTION
noticed that both asciidoctor 1.5.2 and 1.5.1 were used in this project, so I took the chance to align them by upgrading to the most recent version 1.5.3.