### PR TITLE
Apache VFS FileObject optimisation for VFS.cat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
 
 allprojects {
     ext {
-        versionModifier = 'beta7'
+        versionModifier = 'beta8'
         versionNumber   = '1.0'
         modulesWithGroovyDoc = [
             'dsl',

--- a/dsl/src/main/groovy/org/ysb33r/groovy/dsl/vfs/VFS.groovy
+++ b/dsl/src/main/groovy/org/ysb33r/groovy/dsl/vfs/VFS.groovy
@@ -338,15 +338,21 @@ class VFS {
 	def cat ( Map properties=[:],uri,Closure c ) {
 		assert properties != null
         assert c != null
-        FileObject fo=resolveURI(properties,uri)
-        AbstractFileSystem afs= fo.fileSystem as AbstractFileSystem
 
-        try {
-		    return fo.content.inputStream.withStream(c)
-        }
-        finally {
-            afs.closeCommunicationLink()
-        }
+		if( uri instanceof FileObject && !properties.size()) {
+			return uri.content.inputStream.withStream(c)
+		} else {
+			FileObject fo=resolveURI(properties,uri)
+			AbstractFileSystem afs= fo.fileSystem as AbstractFileSystem
+
+			try {
+				return fo.content.inputStream.withStream(c)
+			}
+			finally {
+				afs.closeCommunicationLink()
+			}
+
+		}
 	}
 
 	/** Write content to a local or remote file object


### PR DESCRIPTION
When URI is a FileObject in cat method and no additional properties has been passed, do not close the object at the end of the closure